### PR TITLE
Update deprecated `eachDecl` call to `walkDecls`

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ module.exports = postcss.plugin("postcss-epub", function(opts) {
 	 * @param {Object} css
 	 */
 	return function(css) {
-		css.eachDecl(function(decl) {
+		css.walkDecls(function(decl) {
 			if (decl.value) {
 				if (props.indexOf(decl.prop) >= 0) {
 					decl.parent.insertBefore(decl, decl.clone({


### PR DESCRIPTION
The `Container.eachDecl` method was deprecated in [PostCSS v5.0.0](https://github.com/postcss/postcss/releases/tag/5.0.0) and prints a warning to the console:
`Container#eachDecl is deprecated. Use Container#walkDecls instead.`

The method has simply been renamed; the function signature and behaviour is the same.